### PR TITLE
Add session status field to session model

### DIFF
--- a/app/src/services/firebase/sessionService.test.ts
+++ b/app/src/services/firebase/sessionService.test.ts
@@ -51,6 +51,7 @@ const baseSession: Omit<Session, 'id'> = {
   favoriteTitles: ['title-1'],
   swipes: [],
   createdAt: 1234567890,
+  sessionStatus: 'awaiting',
 };
 
 describe('SessionService', () => {
@@ -87,6 +88,7 @@ describe('SessionService', () => {
     const storedSession: Omit<Session, 'id'> = {
       ...baseSession,
       genres: ['comedy'],
+      sessionStatus: 'in progress',
     };
     getDocMock.mockResolvedValueOnce({
       exists: () => true,

--- a/app/src/types/session.ts
+++ b/app/src/types/session.ts
@@ -1,5 +1,7 @@
 import { Swipe } from './swipe';
 
+export type SessionStatus = 'awaiting' | 'in progress' | 'complete';
+
 export interface Session {
   id: string;
   userIds: [string, string];
@@ -10,4 +12,5 @@ export interface Session {
   swipes: Swipe[];
   matchedTitles?: string[];
   createdAt: number;
+  sessionStatus: SessionStatus;
 }


### PR DESCRIPTION
## Summary
- add a sessionStatus enum type to the session model
- update session service tests to include the new status values

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_690ad987c2788322b29fc48fae86dadd