### PR TITLE
Add recommendation screen and matched title logic

### DIFF
--- a/app/src/navigation/AppNavigator.tsx
+++ b/app/src/navigation/AppNavigator.tsx
@@ -14,6 +14,7 @@ import GenreSelectionScreen from "../screens/GenreSelectionScreen";
 import PlatformSelectionScreen from "../screens/PlatformSelectionScreen";
 import FavoriteMediaSelectionScreen from "../screens/FavoriteMediaScreen";
 import SessionTypeSelectionScreen from "../screens/SessionTypeSelectionScreen"
+import RecommendationScreen from "../screens/RecommendationScreen";
 
 const Stack = createStackNavigator<RootStackParamList>();
 
@@ -104,9 +105,15 @@ export default function AppNavigator() {
                 />
 
                 { /* Movie Swip Screen */ }
-                <Stack.Screen 
-                    name="MovieSwipe" 
+                <Stack.Screen
+                    name="MovieSwipe"
                     component={MovieSwipeScreen}
+                    options={{ headerShown: false }}
+                />
+                { /* Recommendation Screen */ }
+                <Stack.Screen
+                    name="RecommendationScreen"
+                    component={RecommendationScreen}
                     options={{ headerShown: false }}
                 />
             </Stack.Navigator>

--- a/app/src/screens/RecommendationScreen.tsx
+++ b/app/src/screens/RecommendationScreen.tsx
@@ -1,0 +1,249 @@
+import React, { useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  FlatList,
+  Image,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import type { StackScreenProps } from '@react-navigation/stack';
+
+import { SessionService } from '../services/firebase/sessionService';
+import type { MatchedTitle, Session } from '../types/session';
+import type { RootStackParamList } from '../types/navigation';
+
+type Props = StackScreenProps<RootStackParamList, 'RecommendationScreen'>;
+
+const RecommendationScreen: React.FC<Props> = ({ route, navigation }) => {
+  const { sessionId } = route.params;
+  const [session, setSession] = useState<Session | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const unsubscribe = SessionService.subscribeToSession(
+      sessionId,
+      (updatedSession) => {
+        setSession(updatedSession);
+        setLoading(false);
+      },
+      (subscriptionError) => {
+        console.error('Recommendation listener error:', subscriptionError);
+        setError('Unable to load recommendations right now.');
+        setLoading(false);
+      }
+    );
+
+    return () => {
+      unsubscribe();
+    };
+  }, [sessionId]);
+
+  const matchedTitles = session?.matchedTitles ?? [];
+
+  const handleWatchTogether = () => {
+    Alert.alert('Watch Together', 'Feature coming soon!');
+  };
+
+  const handleStartNewSession = () => {
+    navigation.navigate('Home');
+  };
+
+  const renderMatchedItem = ({ item }: { item: MatchedTitle }) => {
+    const streamingText = item.streamingServices?.length
+      ? item.streamingServices.join(', ')
+      : 'Streaming availability unknown';
+
+    return (
+      <View style={styles.card}>
+        {item.posterUrl ? (
+          <Image source={{ uri: item.posterUrl }} style={styles.poster} resizeMode="cover" />
+        ) : (
+          <View style={[styles.poster, styles.posterPlaceholder]}>
+            <Text style={styles.posterPlaceholderText}>No Image</Text>
+          </View>
+        )}
+        <View style={styles.cardContent}>
+          <Text style={styles.cardTitle}>{item.title}</Text>
+          <Text style={styles.cardSubtext}>{streamingText}</Text>
+        </View>
+      </View>
+    );
+  };
+
+  if (loading) {
+    return (
+      <SafeAreaView style={styles.container}>
+        <View style={styles.centerContent}>
+          <ActivityIndicator size="large" color="#E50914" />
+          <Text style={styles.statusText}>Loading recommendations...</Text>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  if (error) {
+    return (
+      <SafeAreaView style={styles.container}>
+        <View style={styles.centerContent}>
+          <Text style={styles.errorText}>{error}</Text>
+          <TouchableOpacity style={styles.primaryButton} onPress={handleStartNewSession}>
+            <Text style={styles.primaryButtonText}>Back to Home</Text>
+          </TouchableOpacity>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.header}>
+        <Text style={styles.headerTitle}>You matched!</Text>
+        <Text style={styles.headerSubtitle}>
+          {matchedTitles.length > 0
+            ? 'Here are the titles you both loved.'
+            : 'No mutual matches yet.'}
+        </Text>
+      </View>
+
+      {matchedTitles.length > 0 ? (
+        <FlatList
+          data={matchedTitles}
+          keyExtractor={(item) => item.id}
+          renderItem={renderMatchedItem}
+          contentContainerStyle={styles.listContent}
+        />
+      ) : (
+        <View style={styles.centerContent}>
+          <Text style={styles.statusText}>Try swiping on a few more titles.</Text>
+        </View>
+      )}
+
+      <View style={styles.footer}>
+        <TouchableOpacity style={styles.primaryButton} onPress={handleWatchTogether}>
+          <Text style={styles.primaryButtonText}>Watch Together</Text>
+        </TouchableOpacity>
+        <TouchableOpacity style={styles.secondaryButton} onPress={handleStartNewSession}>
+          <Text style={styles.secondaryButtonText}>Start New Session</Text>
+        </TouchableOpacity>
+      </View>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#0f141f',
+  },
+  header: {
+    paddingHorizontal: 24,
+    paddingTop: 32,
+  },
+  headerTitle: {
+    fontSize: 28,
+    fontWeight: '700',
+    color: '#ffffff',
+  },
+  headerSubtitle: {
+    marginTop: 8,
+    fontSize: 16,
+    color: '#d1d5db',
+  },
+  listContent: {
+    paddingHorizontal: 24,
+    paddingTop: 16,
+    paddingBottom: 120,
+  },
+  card: {
+    flexDirection: 'row',
+    backgroundColor: '#1f2937',
+    borderRadius: 16,
+    marginBottom: 16,
+    overflow: 'hidden',
+  },
+  poster: {
+    width: 100,
+    height: 150,
+    backgroundColor: '#111827',
+  },
+  posterPlaceholder: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  posterPlaceholderText: {
+    color: '#9ca3af',
+    fontSize: 12,
+  },
+  cardContent: {
+    flex: 1,
+    padding: 16,
+    justifyContent: 'center',
+  },
+  cardTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: '#f9fafb',
+    marginBottom: 8,
+  },
+  cardSubtext: {
+    fontSize: 14,
+    color: '#d1d5db',
+  },
+  centerContent: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 24,
+  },
+  statusText: {
+    marginTop: 16,
+    fontSize: 16,
+    color: '#d1d5db',
+    textAlign: 'center',
+  },
+  errorText: {
+    fontSize: 16,
+    color: '#fca5a5',
+    marginBottom: 24,
+    textAlign: 'center',
+  },
+  footer: {
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    padding: 24,
+    gap: 12,
+    backgroundColor: '#0f141fcc',
+  },
+  primaryButton: {
+    backgroundColor: '#ef4444',
+    paddingVertical: 16,
+    borderRadius: 12,
+    alignItems: 'center',
+  },
+  primaryButtonText: {
+    color: '#ffffff',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  secondaryButton: {
+    paddingVertical: 14,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: '#4b5563',
+    alignItems: 'center',
+  },
+  secondaryButtonText: {
+    color: '#e5e7eb',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+});
+
+export default RecommendationScreen;

--- a/app/src/services/firebase/sessionService.test.ts
+++ b/app/src/services/firebase/sessionService.test.ts
@@ -50,6 +50,7 @@ const baseSession: Omit<Session, 'id'> = {
   streamingServices: ['netflix'],
   favoriteTitles: ['title-1'],
   swipes: [],
+  matchedTitles: [],
   createdAt: 1234567890,
   sessionStatus: 'awaiting',
   playerStatus: { 'user-1': 'awaiting' },
@@ -477,6 +478,32 @@ describe('SessionService', () => {
         userIds: ['host-user', 'guest-user'],
         playerStatus: { 'host-user': 'done', 'guest-user': 'awaiting' },
         sessionStatus: 'in progress' as const,
+        swipes: [
+          {
+            id: 'swipe-1',
+            userId: 'host-user',
+            mediaId: 'movie-1',
+            mediaTitle: 'Movie 1',
+            decision: 'like' as const,
+            createdAt: 1,
+          },
+          {
+            id: 'swipe-2',
+            userId: 'guest-user',
+            mediaId: 'movie-1',
+            mediaTitle: 'Movie 1',
+            decision: 'like' as const,
+            createdAt: 2,
+          },
+          {
+            id: 'swipe-3',
+            userId: 'guest-user',
+            mediaId: 'movie-2',
+            mediaTitle: 'Movie 2',
+            decision: 'dislike' as const,
+            createdAt: 3,
+          },
+        ],
       };
 
       getDocMock.mockResolvedValueOnce({
@@ -493,6 +520,12 @@ describe('SessionService', () => {
         {
           'playerStatus.guest-user': 'done',
           sessionStatus: 'complete',
+          matchedTitles: [
+            {
+              id: 'movie-1',
+              title: 'Movie 1',
+            },
+          ],
         }
       );
     });

--- a/app/src/types/navigation.ts
+++ b/app/src/types/navigation.ts
@@ -14,6 +14,7 @@ export type RootStackParamList = {
   PlatformSelection: PlatformSelectionParams;
   FavoriteMediaSelection: FavoriteMediaSelectionParams;
   SessionTypeSelection: SessionTypeSelectionParams;
+  RecommendationScreen: RecommendationScreenParams;
 };
 
 // Individual Screen Params Info
@@ -56,6 +57,10 @@ export interface PlatformSelectionParams {
 
 export interface FavoriteMediaSelectionParams {
     userId: string;
+}
+
+export interface RecommendationScreenParams {
+    sessionId: string;
 }
 
 

--- a/app/src/types/session.ts
+++ b/app/src/types/session.ts
@@ -4,6 +4,13 @@ export type SessionStatus = 'awaiting' | 'in progress' | 'complete';
 
 export type PlayerReadiness = 'awaiting' | 'done';
 
+export interface MatchedTitle {
+  id: string;
+  title: string;
+  posterUrl?: string;
+  streamingServices?: string[];
+}
+
 export interface Session {
   id: string;
   userIds: string[];
@@ -12,7 +19,7 @@ export interface Session {
   streamingServices: string[];
   favoriteTitles: string[];
   swipes: Swipe[];
-  matchedTitles?: string[];
+  matchedTitles?: MatchedTitle[];
   createdAt: number;
   sessionStatus: SessionStatus;
   playerStatus: Record<string, PlayerReadiness>;

--- a/app/src/types/swipe.ts
+++ b/app/src/types/swipe.ts
@@ -4,6 +4,9 @@ export interface Swipe {
   id: string;
   userId: string;
   mediaId: string;
+  mediaTitle?: string;
+  posterUrl?: string;
+  streamingServices?: string[];
   decision: SwipeDecision;
   createdAt: number;
 }


### PR DESCRIPTION
## Summary
- add a RecommendationScreen that listens for session updates and surfaces shared picks with streaming metadata
- compute matched titles when both players finish swiping and persist them along with session completion status
- enrich stored swipe entries with media context and update the swipe screen flow and navigation to redirect to recommendations

## Testing
- npm run test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911766fe6848322b5243a2cb3e97d43)