### PR TITLE
Remove back to lobby option during match waiting state

### DIFF
--- a/app/src/screens/MovieSwipeScreen.tsx
+++ b/app/src/screens/MovieSwipeScreen.tsx
@@ -250,12 +250,6 @@ export default function MovieSwipeScreen({ route, navigation }: Props) {
           <Text style={styles.noMoreSubtext}>
             Waiting for your partner to finish...
           </Text>
-          <TouchableOpacity
-            style={styles.retryButton}
-            onPress={() => navigation.goBack()}
-          >
-            <Text style={styles.retryButtonText}>Back to Lobby</Text>
-          </TouchableOpacity>
         </View>
       </SafeAreaView>
     );


### PR DESCRIPTION
## Summary
- remove the Back to Lobby button from the waiting-for-partner state on the movie swipe screen

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691279fcaa4c8322ac5793faa39e532d)