### PR TITLE
Standardize MovieProvider interface and unify all consumers

### DIFF
--- a/app/src/screens/FavoriteMediaScreen.tsx
+++ b/app/src/screens/FavoriteMediaScreen.tsx
@@ -12,11 +12,11 @@ import {
   Image,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { searchMoviesByTitle, getPopularMovies } from '../services/api/mediaApiService';
 import { UserService } from '../services/firebase/userService';
 import { UserManager } from '../services/firebase/userManager';
 import type { Media } from '../types/media';
 import { styles } from "../styles/FavoriteMediaStyles";
+import { movieProvider } from '../services/movies/providerRegistry';
 
 type Props = {
   route: {
@@ -81,7 +81,7 @@ const filterValidMedia = (data: Media[]) => {
 const loadPopularMovies = async () => {
   try {
     setSearching(true);
-    const popular = await getPopularMovies('netflix', 'us');
+    const popular = await movieProvider.getPopularMovies({ service: 'netflix', country: 'us' });
 
     const cleaned = filterValidMedia(popular);
 
@@ -102,7 +102,7 @@ const handleSearch = async () => {
 
   try {
     setSearching(true);
-    const results = await searchMoviesByTitle(searchQuery, 'us');
+    const results = await movieProvider.searchMoviesByTitle(searchQuery, 'us');
 
     const cleaned = filterValidMedia(results);
 

--- a/app/src/screens/GenreSelectionScreen.tsx
+++ b/app/src/screens/GenreSelectionScreen.tsx
@@ -9,13 +9,13 @@ import {
   Alert,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { getAvailableGenres } from '../services/api/mediaApiService';
 import type { Genre } from '../types/genre';
 import SelectableCard from "../components/SelectableCard";
 import { UserService } from '../services/firebase/userService';
 import { UserManager } from '../services/firebase/userManager';
 import { styles } from '../styles/GenreSelectionStyles';
 import { ImageSourcePropType } from 'react-native';
+import { movieProvider } from '../services/movies/providerRegistry';
 
 type Props = {
   route: {
@@ -57,7 +57,7 @@ export default function GenreSelectionScreen({ route, navigation }: Props) {
         }
 
         // Load genre list
-        const fetchedGenres = await getAvailableGenres();
+        const fetchedGenres = await movieProvider.getAvailableGenres();
         setGenres(fetchedGenres);
 
       } catch (err: any) {
@@ -83,7 +83,7 @@ export default function GenreSelectionScreen({ route, navigation }: Props) {
     const loadGenres = useCallback(async () => {
       try {
         setLoading(true);
-        const fetchedGenres = await getAvailableGenres();
+        const fetchedGenres = await movieProvider.getAvailableGenres();
         setGenres(fetchedGenres);
       } catch (err: any) {
         console.error('Error loading genres:', err);

--- a/app/src/screens/MovieSwipeScreen.tsx
+++ b/app/src/screens/MovieSwipeScreen.tsx
@@ -189,6 +189,7 @@ export default function MovieSwipeScreen({ route, navigation }: Props) {
           selectedTypes: typesToFetch,
           selectedGenres: [],
           selectedPlatforms: [],
+          favoriteMedia: userData.preferences.favoriteMedia || [],
         },
         'us',
         { limit: 10, orderBy: 'popularity_1year' }

--- a/app/src/screens/ProfileScreen.tsx
+++ b/app/src/screens/ProfileScreen.tsx
@@ -5,7 +5,7 @@ import UserService from "../services/firebase/userService";
 import FooterNav from "../components/FooterNav";
 import { styles } from "../styles/ProfileScreenStyles"; // adjust path as needed
 import { Media } from "../types/media";
-import { getMovieById } from "../services/api/mediaApiService";
+import { movieProvider } from "../services/movies/providerRegistry";
 
 export default function ProfileScreen({ navigation }: any) {
   const [user, setUser] = useState<any>(null);
@@ -33,7 +33,7 @@ export default function ProfileScreen({ navigation }: any) {
 
       try {
         const mediaObjects: Media[] = await Promise.all(
-          user.preferences.favoriteMedia.map((id: string) => getMovieById(id))
+          user.preferences.favoriteMedia.map((id: string) => movieProvider.getMovieById(id))
         );
         setFavoriteMedia(mediaObjects);
       } catch (error) {

--- a/app/src/services/movies/MovieProvider.ts
+++ b/app/src/services/movies/MovieProvider.ts
@@ -1,20 +1,28 @@
+import type { Genre } from '../../types/genre';
 import type { Media } from '../../types/media';
+import type { User } from '../../types/user';
+
+export type UserPreferences = User['preferences'];
+
+export type PreferenceQueryOptions = {
+  minRating?: number;
+  yearMin?: number;
+  yearMax?: number;
+  keyword?: string;
+  orderBy?: 'original_title' | 'popularity_1year' | 'popularity_1month' | 'popularity_1week' | 'popularity_alltime';
+  limit?: number;
+  page?: number;
+};
 
 export interface MovieProvider {
+  getAvailableGenres(): Promise<Genre[]>;
+  getPopularMovies(options?: { service?: 'netflix' | 'prime' | 'apple'; country?: string; limit?: number }): Promise<Media[]>;
+  searchMoviesByTitle(query: string, country?: string): Promise<Media[]>;
+  getMovieById(id: string, country?: string): Promise<Media>;
   getMoviesByPreferences(
-    preferences: {
-      selectedTypes: ('movie' | 'show')[];
-      selectedGenres: string[];
-      selectedPlatforms: string[];
-    },
-    country: string,
-    options?: {
-      minRating?: number;
-      yearMin?: number;
-      yearMax?: number;
-      keyword?: string;
-      orderBy?: string;
-      limit?: number;
-    }
+    preferences: UserPreferences,
+    country?: string,
+    options?: PreferenceQueryOptions
   ): Promise<Media[]>;
+  loadMoreMovies(page?: number): Promise<Media[]>;
 }

--- a/app/src/services/movies/RapidApiMovieProvider.ts
+++ b/app/src/services/movies/RapidApiMovieProvider.ts
@@ -1,16 +1,65 @@
-import { MovieProvider } from './MovieProvider';
-import { getMoviesByPreferences as realGetMovies } from '../../services/api/mediaApiService';
+import type { MovieProvider, PreferenceQueryOptions, UserPreferences } from './MovieProvider';
+import {
+  getAvailableGenres as realGetAvailableGenres,
+  getMovieById as realGetMovieById,
+  getMoviesByPreferences as realGetMovies,
+  getPopularMovies as realGetPopularMovies,
+  searchMoviesByTitle as realSearchMoviesByTitle,
+} from '../api/mediaApiService';
 
-type MoviePreferences = Parameters<MovieProvider['getMoviesByPreferences']>[0];
-type CountryCode = Parameters<MovieProvider['getMoviesByPreferences']>[1];
-type MovieOptions = Parameters<MovieProvider['getMoviesByPreferences']>[2];
+const DEFAULT_PAGE_SIZE = 20;
 
 export class RapidApiMovieProvider implements MovieProvider {
+  private lastPreferences?: UserPreferences;
+  private lastCountry: string = 'us';
+  private lastOptions?: PreferenceQueryOptions;
+
+  async getAvailableGenres() {
+    return realGetAvailableGenres();
+  }
+
+  async getPopularMovies(options?: { service?: 'netflix' | 'prime' | 'apple'; country?: string; limit?: number }) {
+    const service = options?.service ?? 'netflix';
+    const country = options?.country ?? 'us';
+    const movies = await realGetPopularMovies(service, country);
+
+    if (typeof options?.limit === 'number') {
+      return movies.slice(0, options.limit);
+    }
+
+    return movies;
+  }
+
+  async searchMoviesByTitle(query: string, country: string = 'us') {
+    return realSearchMoviesByTitle(query, country);
+  }
+
+  async getMovieById(id: string, country: string = 'us') {
+    return realGetMovieById(id, country);
+  }
+
   async getMoviesByPreferences(
-    preferences: MoviePreferences,
-    country: CountryCode,
-    options?: MovieOptions
+    preferences: UserPreferences,
+    country: string = 'us',
+    options?: PreferenceQueryOptions
   ) {
-    return realGetMovies(preferences, country, options as Parameters<typeof realGetMovies>[2]);
+    this.lastPreferences = preferences;
+    this.lastCountry = country;
+    this.lastOptions = options;
+    return realGetMovies(preferences, country, options);
+  }
+
+  async loadMoreMovies(page?: number) {
+    if (!this.lastPreferences) {
+      throw new Error('No previous preference query to load more results from');
+    }
+
+    const options: PreferenceQueryOptions = {
+      ...this.lastOptions,
+      page,
+      limit: this.lastOptions?.limit ?? DEFAULT_PAGE_SIZE,
+    };
+
+    return this.getMoviesByPreferences(this.lastPreferences, this.lastCountry, options);
   }
 }

--- a/app/src/services/movies/StaticMovieProvider.ts
+++ b/app/src/services/movies/StaticMovieProvider.ts
@@ -1,17 +1,207 @@
-import { MovieProvider } from './MovieProvider';
+import type { MovieProvider, PreferenceQueryOptions, UserPreferences } from './MovieProvider';
+import type { Genre } from '../../types/genre';
 import type { Media } from '../../types/media';
 import staticMovies from './staticMovies';
 
-type MoviePreferences = Parameters<MovieProvider['getMoviesByPreferences']>[0];
-type CountryCode = Parameters<MovieProvider['getMoviesByPreferences']>[1];
-type MovieOptions = Parameters<MovieProvider['getMoviesByPreferences']>[2];
+const DEFAULT_PAGE_SIZE = 20;
 
 export class StaticMovieProvider implements MovieProvider {
+  private readonly movies: Media[];
+  private readonly genres: Genre[];
+  private lastPreferences?: UserPreferences;
+  private lastCountry: string = 'us';
+  private lastOptions?: PreferenceQueryOptions;
+
+  constructor(data: Media[] = staticMovies) {
+    this.movies = data;
+    this.genres = this.buildGenres(data);
+  }
+
+  async getAvailableGenres() {
+    return this.genres;
+  }
+
+  async getPopularMovies(options?: { service?: 'netflix' | 'prime' | 'apple'; country?: string; limit?: number }) {
+    const limit = options?.limit ?? DEFAULT_PAGE_SIZE;
+    const country = options?.country ?? 'us';
+    const sorted = [...this.movies].sort((a, b) => (b.rating ?? 0) - (a.rating ?? 0));
+    return this.normalizeForCountry(sorted.slice(0, limit), country);
+  }
+
+  async searchMoviesByTitle(query: string, country: string = 'us') {
+    if (!query.trim()) {
+      return [];
+    }
+
+    const lowerQuery = query.toLowerCase();
+    const results = this.movies.filter(
+      (movie) =>
+        movie.title.toLowerCase().includes(lowerQuery) ||
+        movie.overview?.toLowerCase().includes(lowerQuery)
+    );
+
+    return this.normalizeForCountry(results, country);
+  }
+
+  async getMovieById(id: string, country: string = 'us') {
+    const match = this.movies.find((movie) => movie.id === id);
+    return match ? this.normalizeForCountry([match], country)[0] : this.createFallbackMovie(id);
+  }
+
   async getMoviesByPreferences(
-    _preferences: MoviePreferences,
-    _country: CountryCode,
-    _options?: MovieOptions
+    preferences: UserPreferences,
+    country: string = 'us',
+    options?: PreferenceQueryOptions
   ): Promise<Media[]> {
-    return staticMovies;
+    this.lastPreferences = preferences;
+    this.lastCountry = country;
+    this.lastOptions = options;
+
+    const filtered = this.movies.filter((movie) => {
+      if (preferences.selectedTypes?.length && !preferences.selectedTypes.includes(movie.mediaType)) {
+        return false;
+      }
+
+      if (!this.matchesGenres(movie, preferences.selectedGenres)) {
+        return false;
+      }
+
+      if (!this.matchesPlatforms(movie, preferences.selectedPlatforms)) {
+        return false;
+      }
+
+      if (options?.minRating !== undefined && (movie.rating ?? 0) < options.minRating) {
+        return false;
+      }
+
+      if (options?.yearMin !== undefined && movie.releaseYear && movie.releaseYear < options.yearMin) {
+        return false;
+      }
+
+      if (options?.yearMax !== undefined && movie.releaseYear && movie.releaseYear > options.yearMax) {
+        return false;
+      }
+
+      if (options?.keyword) {
+        const keyword = options.keyword.toLowerCase();
+        if (
+          !movie.title.toLowerCase().includes(keyword) &&
+          !movie.overview?.toLowerCase().includes(keyword)
+        ) {
+          return false;
+        }
+      }
+
+      return true;
+    });
+
+    const sorted = this.sortMovies(filtered, options?.orderBy);
+    return this.paginateAndNormalize(sorted, country, options);
+  }
+
+  async loadMoreMovies(page?: number): Promise<Media[]> {
+    const hasPreviousQuery = !!this.lastPreferences;
+    const nextPage = page ?? (hasPreviousQuery ? (this.lastOptions?.page ?? 1) + 1 : 1);
+    const fallbackPreferences: UserPreferences = this.lastPreferences ?? {
+      selectedTypes: ['movie'],
+      selectedGenres: [],
+      selectedPlatforms: [],
+      favoriteMedia: [],
+    };
+
+    const fallbackOptions: PreferenceQueryOptions = this.lastOptions ?? {
+      limit: DEFAULT_PAGE_SIZE,
+      page: nextPage,
+    };
+
+    return this.getMoviesByPreferences(fallbackPreferences, this.lastCountry, {
+      ...fallbackOptions,
+      page: nextPage,
+      limit: fallbackOptions.limit ?? DEFAULT_PAGE_SIZE,
+    });
+  }
+
+  private buildGenres(data: Media[]): Genre[] {
+    const seen = new Map<string, string>();
+    data.forEach((movie) => {
+      movie.genres.forEach((name) => {
+        const id = name.toLowerCase();
+        if (!seen.has(id)) {
+          seen.set(id, name);
+        }
+      });
+    });
+
+    return Array.from(seen.entries()).map(([id, name]) => ({ id, name }));
+  }
+
+  private matchesGenres(movie: Media, selectedGenres: string[]) {
+    if (!selectedGenres?.length) return true;
+    const movieGenres = movie.genres.map((g) => g.toLowerCase());
+    return selectedGenres.every((genre) => movieGenres.includes(genre.toLowerCase()));
+  }
+
+  private matchesPlatforms(movie: Media, selectedPlatforms: string[]) {
+    if (!selectedPlatforms?.length) return true;
+    const movieServices = movie.streamingOptions.flatMap((option) =>
+      option.services.map((svc) => svc.serviceName.toLowerCase())
+    );
+    return selectedPlatforms.some((platform) => movieServices.includes(platform.toLowerCase()));
+  }
+
+  private sortMovies(movies: Media[], orderBy?: PreferenceQueryOptions['orderBy']) {
+    const ordered = [...movies];
+    if (!orderBy) {
+      return ordered;
+    }
+
+    switch (orderBy) {
+      case 'popularity_1year':
+      case 'popularity_1month':
+      case 'popularity_1week':
+      case 'popularity_alltime':
+        return ordered.sort((a, b) => (b.rating ?? 0) - (a.rating ?? 0));
+      case 'original_title':
+        return ordered.sort((a, b) => a.title.localeCompare(b.title));
+      default:
+        return ordered;
+    }
+  }
+
+  private paginateAndNormalize(movies: Media[], country: string, options?: PreferenceQueryOptions) {
+    const limit = options?.limit ?? DEFAULT_PAGE_SIZE;
+    const page = options?.page && options.page > 0 ? options.page : 1;
+    const start = (page - 1) * limit;
+    const end = start + limit;
+
+    const pageItems = movies.slice(start, end);
+    return this.normalizeForCountry(pageItems, country);
+  }
+
+  private normalizeForCountry(movies: Media[], country: string) {
+    return movies.map((movie) => ({
+      ...movie,
+      streamingOptions: movie.streamingOptions.filter(
+        (option) => option.countryCode.toLowerCase() === country.toLowerCase()
+      ),
+    }));
+  }
+
+  private createFallbackMovie(id: string): Media {
+    return {
+      id,
+      mediaType: 'movie',
+      title: 'Unknown Title',
+      overview: 'Details unavailable in offline mode.',
+      genres: [],
+      directors: [],
+      cast: [],
+      streamingOptions: [],
+      releaseYear: new Date().getFullYear(),
+      runtime: 0,
+      rating: 0,
+      poster: undefined,
+      trailerUrl: undefined,
+    };
   }
 }

--- a/app/src/services/movies/providerRegistry.ts
+++ b/app/src/services/movies/providerRegistry.ts
@@ -1,7 +1,6 @@
+import type { MovieProvider } from './MovieProvider';
 import { StaticMovieProvider } from './StaticMovieProvider';
 import { RapidApiMovieProvider } from './RapidApiMovieProvider';
 
-export const movieProvider = new StaticMovieProvider();
-
-// To switch to RapidAPI, change to:
-// export const movieProvider = new RapidApiMovieProvider();
+// export const movieProvider: MovieProvider = new StaticMovieProvider();
+export const movieProvider: MovieProvider = new RapidApiMovieProvider();

--- a/app/src/tests/unit/services/api/mediaApiService.test.ts
+++ b/app/src/tests/unit/services/api/mediaApiService.test.ts
@@ -130,6 +130,7 @@ describe('MovieApi', () => {
           selectedTypes: ['movie'],
           selectedGenres: ['action'],
           selectedPlatforms: ['netflix', 'prime'],
+          favoriteMedia: [],
         },
         'us'
       );
@@ -159,6 +160,7 @@ describe('MovieApi', () => {
           selectedTypes: [],
           selectedGenres: [],
           selectedPlatforms: [],
+          favoriteMedia: [],
         },
         'us'
       );
@@ -181,6 +183,7 @@ describe('MovieApi', () => {
           selectedTypes: ['movie'],
           selectedGenres: ['action', 'comedy'],
           selectedPlatforms: ['netflix'],
+          favoriteMedia: [],
         },
         'us',
         {
@@ -226,6 +229,7 @@ describe('MovieApi', () => {
           selectedTypes: ['movie'],
           selectedGenres: [],
           selectedPlatforms: [],
+          favoriteMedia: [],
         },
         'us',
         { limit: 5 }
@@ -248,6 +252,7 @@ describe('MovieApi', () => {
           selectedTypes: ['movie'],
           selectedGenres: ['action'],
           selectedPlatforms: [],
+          favoriteMedia: [],
         },
         'us'
       );
@@ -264,6 +269,7 @@ describe('MovieApi', () => {
           selectedTypes: ['movie'],
           selectedGenres: [],
           selectedPlatforms: [],
+          favoriteMedia: [],
         })
       ).rejects.toThrow('Failed to fetch movies');
     });

--- a/app/src/tests/unit/services/movies/movieProviders.test.ts
+++ b/app/src/tests/unit/services/movies/movieProviders.test.ts
@@ -1,122 +1,175 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-
-// mock the mediaApiService module
-vi.mock('../../../../services/api/mediaApiService', () => ({
-  getMoviesByPreferences: vi.fn()
-}));
-
-// modules under test
-import { movieProvider } from '../../../../services/movies/providerRegistry';
 import { StaticMovieProvider } from '../../../../services/movies/StaticMovieProvider';
 import { RapidApiMovieProvider } from '../../../../services/movies/RapidApiMovieProvider';
 import staticMovies from '../../../../services/movies/staticMovies';
-
-// external dependency to mock
 import * as mediaApiService from '../../../../services/api/mediaApiService';
 
-describe('Movie Providers', () => {
-  // ---------------------------------------------------------------------------
-  // StaticMovieProvider
-  // ---------------------------------------------------------------------------
-  describe('StaticMovieProvider', () => {
-    const provider = new StaticMovieProvider();
+vi.mock('../../../../services/api/mediaApiService', () => ({
+  getMoviesByPreferences: vi.fn(),
+  getAvailableGenres: vi.fn(),
+  getPopularMovies: vi.fn(),
+  searchMoviesByTitle: vi.fn(),
+  getMovieById: vi.fn(),
+}));
 
-    it('should return the staticMovies array', async () => {
-      const result = await provider.getMoviesByPreferences(
-        { selectedTypes: [], selectedGenres: [], selectedPlatforms: [] },
+const mockedApi = mediaApiService as unknown as {
+  getMoviesByPreferences: ReturnType<typeof vi.fn>;
+  getAvailableGenres: ReturnType<typeof vi.fn>;
+  getPopularMovies: ReturnType<typeof vi.fn>;
+  searchMoviesByTitle: ReturnType<typeof vi.fn>;
+  getMovieById: ReturnType<typeof vi.fn>;
+};
+
+describe('StaticMovieProvider', () => {
+  const provider = new StaticMovieProvider();
+
+  it('returns available genres derived from static dataset', async () => {
+    const genres = await provider.getAvailableGenres();
+
+    expect(genres.length).toBeGreaterThan(0);
+    expect(genres.some((g) => g.name.toLowerCase() === 'drama')).toBe(true);
+  });
+
+  it('searches locally by title without calling network', async () => {
+    const results = await provider.searchMoviesByTitle('dark');
+    expect(results.some((m) => m.title.toLowerCase().includes('dark'))).toBe(true);
+  });
+
+  it('finds movies by ID and normalizes the result', async () => {
+    const movie = await provider.getMovieById(staticMovies[0].id);
+
+    expect(movie.id).toBe(staticMovies[0].id);
+    expect(movie.streamingOptions.every((opt) => opt.countryCode.toLowerCase() === 'us')).toBe(true);
+  });
+
+  it('filters, sorts, and paginates preference queries', async () => {
+    const prefs = {
+      selectedTypes: ['movie'] as const,
+      selectedGenres: ['Drama'],
+      selectedPlatforms: ['Netflix'],
+      favoriteMedia: [],
+    };
+
+    const firstPage = await provider.getMoviesByPreferences(prefs, 'us', {
+      limit: 2,
+      orderBy: 'popularity_alltime',
+      page: 1,
+    });
+
+    expect(firstPage.length).toBeLessThanOrEqual(2);
+    expect(firstPage.every((m) => m.genres.map((g) => g.toLowerCase()).includes('drama'))).toBe(true);
+
+    const secondPage = await provider.loadMoreMovies();
+    expect(secondPage.length).toBeGreaterThanOrEqual(0);
+    if (secondPage.length > 0) {
+      expect(secondPage[0].id).not.toBe(firstPage[0].id);
+    }
+  });
+
+  it('returns popular movies without hitting network', async () => {
+    const popular = await provider.getPopularMovies({ limit: 3 });
+    expect(popular.length).toBeLessThanOrEqual(3);
+  });
+});
+
+describe('RapidApiMovieProvider', () => {
+  let provider: RapidApiMovieProvider;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    provider = new RapidApiMovieProvider();
+  });
+
+  it('delegates preference queries to the media API', async () => {
+    mockedApi.getMoviesByPreferences.mockResolvedValueOnce(['mock-result']);
+
+    const prefs = { selectedTypes: ['movie'], selectedGenres: ['Action'], selectedPlatforms: [], favoriteMedia: [] };
+    const country = 'us';
+    const options = { limit: 10, orderBy: 'popularity_1year' as const };
+
+    const result = await provider.getMoviesByPreferences(prefs, country, options);
+
+    expect(mockedApi.getMoviesByPreferences).toHaveBeenCalledWith(prefs, country, options);
+    expect(result).toEqual(['mock-result']);
+  });
+
+  it('supports pagination via loadMoreMovies', async () => {
+    mockedApi.getMoviesByPreferences.mockResolvedValueOnce(['page-1']);
+
+    const prefs = { selectedTypes: ['movie'], selectedGenres: [], selectedPlatforms: [], favoriteMedia: [] };
+    await provider.getMoviesByPreferences(prefs, 'us', { limit: 5, page: 1 });
+
+    mockedApi.getMoviesByPreferences.mockResolvedValueOnce(['page-2']);
+    const result = await provider.loadMoreMovies(2);
+
+    expect(mockedApi.getMoviesByPreferences).toHaveBeenLastCalledWith(prefs, 'us', {
+      limit: 5,
+      page: 2,
+    });
+    expect(result).toEqual(['page-2']);
+  });
+
+  it('delegates other API methods', async () => {
+    const genres = [{ id: 'action', name: 'Action' }];
+    mockedApi.getAvailableGenres.mockResolvedValueOnce(genres);
+    expect(await provider.getAvailableGenres()).toEqual(genres);
+
+    mockedApi.getPopularMovies.mockResolvedValueOnce(['p1', 'p2', 'p3']);
+    expect(await provider.getPopularMovies({ service: 'prime', country: 'ca', limit: 2 })).toEqual(['p1', 'p2']);
+    expect(mockedApi.getPopularMovies).toHaveBeenCalledWith('prime', 'ca');
+
+    mockedApi.searchMoviesByTitle.mockResolvedValueOnce(['search']);
+    expect(await provider.searchMoviesByTitle('query', 'us')).toEqual(['search']);
+    expect(mockedApi.searchMoviesByTitle).toHaveBeenCalledWith('query', 'us');
+
+    mockedApi.getMovieById.mockResolvedValueOnce('movie');
+    expect(await provider.getMovieById('id', 'us')).toEqual('movie');
+    expect(mockedApi.getMovieById).toHaveBeenCalledWith('id', 'us');
+  });
+
+  it('propagates errors from the underlying API', async () => {
+    mockedApi.getMoviesByPreferences.mockRejectedValueOnce(new Error('API failure'));
+
+    await expect(
+      provider.getMoviesByPreferences(
+        { selectedTypes: [], selectedGenres: [], selectedPlatforms: [], favoriteMedia: [] },
         'us',
-        { limit: 10 }
-      );
+        {},
+      )
+    ).rejects.toThrow('API failure');
+  });
+});
 
-      expect(result).toBe(staticMovies);
-      expect(Array.isArray(result)).toBe(true);
-      expect(result.length).toBeGreaterThan(0);
-    });
-
-    it('should contain fully defined Media objects (no undefined fields)', () => {
-      for (const movie of staticMovies) {
-        for (const [key, value] of Object.entries(movie)) {
-          expect(value).not.toBeUndefined();
-        }
-      }
-    });
+describe('staticMovies data integrity', () => {
+  it('every movie should have required fields', () => {
+    for (const movie of staticMovies) {
+      expect(movie.id).toBeTruthy();
+      expect(movie.mediaType).toBe('movie');
+      expect(movie.title).toBeTruthy();
+      expect(movie.overview).toBeTruthy();
+      expect(movie.genres.length).toBeGreaterThan(0);
+      expect(movie.directors.length).toBeGreaterThan(0);
+      expect(movie.cast.length).toBeGreaterThan(0);
+      expect(movie.streamingOptions.length).toBeGreaterThan(0);
+      expect(typeof movie.releaseYear).toBe('number');
+      expect(typeof movie.runtime).toBe('number');
+      expect(typeof movie.poster).toBe('string');
+      expect(typeof movie.trailerUrl).toBe('string');
+    }
   });
 
-  // ---------------------------------------------------------------------------
-  // RapidApiMovieProvider
-  // ---------------------------------------------------------------------------
-  describe('RapidApiMovieProvider', () => {
-    const mockRealGetMovies = vi.spyOn(mediaApiService, 'getMoviesByPreferences');
+  it('streamingOptions should be valid objects', () => {
+    for (const movie of staticMovies) {
+      for (const group of movie.streamingOptions) {
+        expect(group.countryCode).toBeTruthy();
+        expect(Array.isArray(group.services)).toBe(true);
+        expect(group.services.length).toBeGreaterThan(0);
 
-    beforeEach(() => {
-      mockRealGetMovies.mockReset();
-    });
-
-    it('should delegate to real getMoviesByPreferences with correct args', async () => {
-      const provider = new RapidApiMovieProvider();
-
-      mockRealGetMovies.mockResolvedValue(['mock-result']);
-
-      const prefs = { selectedTypes: ["movie"], selectedGenres: ["Action"], selectedPlatforms: [] };
-      const country = 'us';
-      const options = { limit: 10, orderBy: 'popularity_1year' };
-
-      const result = await provider.getMoviesByPreferences(prefs, country, options);
-
-      expect(mockRealGetMovies).toHaveBeenCalledTimes(1);
-      expect(mockRealGetMovies).toHaveBeenCalledWith(prefs, country, options);
-      expect(result).toEqual(['mock-result']);
-    });
-
-    it('should propagate errors from the underlying API', async () => {
-      const provider = new RapidApiMovieProvider();
-
-      mockRealGetMovies.mockRejectedValue(new Error('API failure'));
-
-      await expect(
-        provider.getMoviesByPreferences(
-          { selectedTypes: [], selectedGenres: [], selectedPlatforms: [] },
-          'us',
-          {},
-        )
-      ).rejects.toThrow('API failure');
-    });
-  });
-
-  // ---------------------------------------------------------------------------
-  // staticMovies dataset integrity
-  // ---------------------------------------------------------------------------
-  describe('staticMovies data integrity', () => {
-    it('every movie should have required fields', () => {
-      for (const movie of staticMovies) {
-        expect(movie.id).toBeTruthy();
-        expect(movie.mediaType).toBe('movie');
-        expect(movie.title).toBeTruthy();
-        expect(movie.overview).toBeTruthy();
-        expect(movie.genres.length).toBeGreaterThan(0);
-        expect(movie.directors.length).toBeGreaterThan(0);
-        expect(movie.cast.length).toBeGreaterThan(0);
-        expect(movie.streamingOptions.length).toBeGreaterThan(0);
-        expect(typeof movie.releaseYear).toBe('number');
-        expect(typeof movie.runtime).toBe('number');
-        expect(typeof movie.poster).toBe('string');
-        expect(typeof movie.trailerUrl).toBe('string');
-      }
-    });
-
-    it('streamingOptions should be valid objects', () => {
-      for (const movie of staticMovies) {
-        for (const group of movie.streamingOptions) {
-          expect(group.countryCode).toBeTruthy();
-          expect(Array.isArray(group.services)).toBe(true);
-          expect(group.services.length).toBeGreaterThan(0);
-
-          for (const svc of group.services) {
-            expect(svc.serviceName).toBeTruthy();
-            expect(typeof svc.logo).toBe('string');
-          }
+        for (const svc of group.services) {
+          expect(svc.serviceName).toBeTruthy();
+          expect(typeof svc.logo).toBe('string');
         }
       }
-    });
+    }
   });
 });


### PR DESCRIPTION
This PR closes #53.

Changes introduced:
- Standardized the provider contract to cover genres, popular/search/id lookups, preference queries, and pagination, and tightened media API typing/pagination handling
- Rebuilt the static provider as a full offline stub with derived genres, local search, id lookup, preference filtering
- Routed UI consumers through the provider abstraction so onboarding/profile flows no longer import RapidAPI helpers directly; provider registry now typed
- Expanded provider unit tests to cover the new interface, offline behaviors, and RapidAPI delegation