### PR TITLE
Guard matching against stale swipes + add deterministic metadata-rich fallback

### DIFF
--- a/app/src/screens/MovieSwipeScreen.tsx
+++ b/app/src/screens/MovieSwipeScreen.tsx
@@ -359,7 +359,8 @@ export default function MovieSwipeScreen({ route, navigation }: Props) {
   if (currentIndex >= movies.length) {
     if (!hasMarkedFinishedRef.current) {
       hasMarkedFinishedRef.current = true;
-      SessionService.markPlayerFinished(sessionId, userId).catch((err) => {
+      const expectedSwipeCount = Math.max(currentIndex, movies.length);
+      SessionService.markPlayerFinished(sessionId, userId, expectedSwipeCount).catch((err) => {
         console.error('Failed to mark player finished:', err);
       });
     }

--- a/app/src/services/firebase/sessionService.ts
+++ b/app/src/services/firebase/sessionService.ts
@@ -356,7 +356,7 @@ export const SessionService = {
 
       if (allPlayersDone && allSwipeCountsSatisfied) {
         const { matchedTitles, algorithmVersion, certainty } =
-          MatchingService.matchSession(swipes, session.userIds);
+          MatchingService.matchSession(swipes, session.userIds, sessionId);
 
         updates.sessionStatus = 'complete';
         updates.matchedTitles = matchedTitles;

--- a/app/src/tests/unit/services/firebase/sessionService.test.ts
+++ b/app/src/tests/unit/services/firebase/sessionService.test.ts
@@ -862,9 +862,15 @@ describe('SessionService', () => {
         data: () => sess,
       });
 
-      await SessionService.markPlayerFinished('session-id', 'u1');
+      await SessionService.markPlayerFinished('session-id', 'u1', 3);
 
-      expect(transactionUpdateMock).toHaveBeenCalled();
+      expect(transactionUpdateMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          'playerStatus.u1': 'done',
+          'expectedSwipeCounts.u1': 3,
+        })
+      );
     });
 
     it('completes session when both done', async () => {
@@ -872,6 +878,7 @@ describe('SessionService', () => {
         ...baseSession,
         userIds: ['u1', 'u2'],
         playerStatus: { u1: 'done', u2: 'awaiting' },
+        expectedSwipeCounts: { u1: 1 },
         swipes: [
           { id: '1', userId: 'u1', mediaId: 'm1', mediaTitle: 'Movie1', decision: 'like', createdAt: 1 },
           { id: '2', userId: 'u2', mediaId: 'm1', mediaTitle: 'Movie1', decision: 'like', createdAt: 2 },
@@ -883,7 +890,7 @@ describe('SessionService', () => {
         data: () => sess,
       });
 
-      await SessionService.markPlayerFinished('session-id', 'u2');
+      await SessionService.markPlayerFinished('session-id', 'u2', 1);
 
       expect(transactionUpdateMock).toHaveBeenCalled();
       const [, payload] = transactionUpdateMock.mock.calls[0];

--- a/app/src/types/session.ts
+++ b/app/src/types/session.ts
@@ -27,4 +27,5 @@ export interface Session {
   createdAt: number;
   sessionStatus: SessionStatus;
   playerStatus: Record<string, PlayerReadiness>;
+  expectedSwipeCounts?: Record<string, number>;
 }


### PR DESCRIPTION
This PR closes #55.

Introduced changes to tighten the client-side matching gate to prevent computing matches on incomplete server-side swipe data + introduces a deterministic fallback for zero-signal sessions.

**Matching gate updates:**

* `markPlayerFinished` now accepts an `expectedSwipeCount`, stores it in `expectedSwipeCounts.{userId}`, and only runs `MatchingService.matchSession` when all players are done **and** each user’s server-visible swipe count meets their expected total.
* If counts are incomplete, it only marks the user as done and defers matching.
* Session type updated to include optional `expectedSwipeCounts`.
* `MovieSwipeScreen` now passes the completed swipe count so the transaction knows the target.
* Unit tests updated to assert the new gating behavior.

**Deterministic fallback improvements:**

* Fallback triggers when the consensus vector is zero or cosine ranking is empty.
* Selection is now seeded with the `sessionId` and draws 3 items from the swiped deck, ensuring both clients see the same “Trending Picks” with full metadata.
* Title construction prefers a like swipe but gracefully falls back to any swipe for that mediaId, eliminating raw-ID rendering.
* `sessionId` is now passed into the matching service, and a new unit test covers the seeded fallback path.
